### PR TITLE
CI: Add GitHub Actions Workflow to Build and Publish Artifact

### DIFF
--- a/.github/workflows/publish-artifact.yml
+++ b/.github/workflows/publish-artifact.yml
@@ -1,0 +1,32 @@
+name: Build and Publish Artifact
+
+on:
+  push:
+    branches:
+      - master # Triggers on pushes to the master branch
+
+jobs:
+  build-and-publish-artifact:
+    runs-on: windows-2025 # Must use Windows for .NET Framework and MSBuild
+
+    steps:
+      # Step 1: Checkout the repository
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      # Step 2: Set up MSBuild
+      - name: Setup MSBuild
+        uses: microsoft/setup-msbuild@v2
+        with:
+          msbuild-architecture: x64
+
+      # Step 3: Build the project in Release mode using MSBuild
+      - name: Build with MSBuild
+        run: msbuild GhidraZipCleaner.sln /p:Configuration=Release /p:Platform="Any CPU"
+
+      # Step 4: Upload the ZIP as an artifact
+      - name: Upload Artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: GhidraZipCleaner
+          path: ./GhidraZipCleaner/bin/Release


### PR DESCRIPTION
First off, thank you for creating this program! GhidraZipCleaner is a fantastic tool for safely sharing Ghidra analysis, and I’ve found it really helpful for my project.

I noticed that there is currently no GitHub Actions workflow to compile the C# code into the executable. To address this, I’ve added a workflow that builds the project in `Release` mode for .NET Framework 4.7.2, packages the binaries into a ZIP file, and uploads it as an artifact. The workflow runs on pushes to the `master` branch.

Adding this workflow is important because it allows users to build the executable directly from the source code, ensuring transparency and reducing the risk of hidden vulnerabilities in precompiled binaries. By compiling from source, users can verify that the executable matches the codebase and hasn’t been tampered with, which is critical for tools handling sensitive data like ROMs in reverse engineering workflows.

Here’s a summary of the changes:
- Added `.github/workflows/publish-artifact.yml` to build the project with `msbuild`, ZIP the binaries, and upload them as an artifact.
- The workflow uses `windows-2025` as the runner and targets .NET Framework 4.7.2, matching the project’s requirements.

It would also be possible to directly create a release in the releases page (https://github.com/GrasonHumphrey/GhidraZipCleaner/releases), but this should suffice for now.